### PR TITLE
respect router prefix during concatenation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "aws-lambda-router",
-  "version": "1.0.0",
+  "name": "@dontepsu/aws-lambda-router",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dontepsu/aws-lambda-router",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Simple API router for AWS lambda and Serverless framework built with TypeScript",
   "main": "lib/index.js",
   "scripts": {

--- a/src/router.ts
+++ b/src/router.ts
@@ -41,10 +41,11 @@ export class Router {
   }
 
   concat (router: Router) {
-    this.routes = {
-      ...this.routes,
-      ...router.routes,
-    };
+    for (let path in router.routes) {
+      for (let method in router.routes[path]) {
+        this.route(router.routes[path][method]);
+      }
+    }
 
     return this;
   }


### PR DESCRIPTION
When doing router.concat(anotherRouter) on a router
with a prefix, add it to all the routes from anotherRouter
(in the same way as prefix is added when doing router.route)