### PR TITLE
Automatically base64 decode the event body (if necessary)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dontepsu/aws-lambda-router",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dontepsu/aws-lambda-router",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Simple API router for AWS lambda and Serverless framework built with TypeScript",
   "main": "lib/index.js",
   "scripts": {

--- a/src/router.ts
+++ b/src/router.ts
@@ -28,6 +28,14 @@ export class Router {
         },
       };
     }
+
+    // if the event body is base64 encoded and not-empty,
+    // decode it before forwarding it to the handler
+    if (event.isBase64Encoded && event.body) {
+      event.body = Buffer.from(event.body, 'base64').toString('utf-8');
+      event.isBase64Encoded = false;
+    }
+
     try {
       if (this.config.onInvoke) {
         await this.config.onInvoke(event, context);


### PR DESCRIPTION
AWS API Gateway encodes some body payloads in base64. It very
convenient when the decoding is handled by the router (in one central
location), instead of each handler function having to do it
separately.